### PR TITLE
Fix ember router deprecation

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -72,7 +72,8 @@ routeProps[mergedActionPropertyName] = {
       })
       .then(function(finalTitle) {
         // Stubbable fn that sets document.title
-        self.router.setTitle(finalTitle);
+        var router = typeof getOwner === 'function' ? getOwner(self).lookup('router:main') : self.router;
+        router.setTitle(finalTitle);
       });
 
       // Tell FastBoot about our async code


### PR DESCRIPTION
In order to avoid future breakage in Ember 3.5, possible collision w/ user-defined properties, and deprecation warnings in Ember 3.1, this small change attempts to obtain the router from the container instead of from the route.

Related deprecation: https://www.emberjs.com/deprecations/v3.x/#toc_ember-routing-route-router

Taken from: https://github.com/kimroen/ember-cli-document-title/pull/75